### PR TITLE
Remove incoherent parameter type

### DIFF
--- a/Doctrine/UserListener.php
+++ b/Doctrine/UserListener.php
@@ -81,9 +81,11 @@ class UserListener implements EventSubscriber
     }
 
     /**
+     * @param EntityManager|DocumentManager $om
+     * @param UserInterface $user
      * Recomputes change set for Doctrine implementations not doing it automatically after the event.
      */
-    private function recomputeChangeSet(EntityManagerInterface $om, UserInterface $user)
+    private function recomputeChangeSet($om, UserInterface $user)
     {
         $meta = $om->getClassMetadata(get_class($user));
 


### PR DESCRIPTION
`recomputeChangeSet` fails on a MongoDB context, because EntityManagerInterface cannot match (and is incoherent with later `instanceof` tests).